### PR TITLE
Update application to use API Read Access Token

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -28,6 +28,7 @@ class APIService {
 			method: 'GET',
 			headers: {
 				'Content-Type': 'application/json',
+				Authorization: `Bearer ${process.env.REACT_APP_API_KEY}`,
 			},
 		})
 		return response.json()

--- a/src/services/movieApiService.js
+++ b/src/services/movieApiService.js
@@ -15,7 +15,6 @@ class MovieAPIService {
 	getTrendingToday() {
 		const queryParams = {
 			page: 1,
-			api_key: this.apiKey,
 		}
 		return this.apiService.get(movieConstants.TRENDING_ENDPOINT, queryParams)
 	}
@@ -30,14 +29,7 @@ class MovieAPIService {
 			throw new Error('ID must be provided')
 		}
 
-		const queryParams = {
-			api_key: this.apiKey,
-		}
-
-		return this.apiService.get(
-			`${movieConstants.SINGLE_ENDPOINT}/${id}`,
-			queryParams,
-		)
+		return this.apiService.get(`${movieConstants.SINGLE_ENDPOINT}/${id}`)
 	}
 
 	/**
@@ -51,7 +43,6 @@ class MovieAPIService {
 		}
 
 		const queryParams = {
-			api_key: this.apiKey,
 			query: name,
 		}
 


### PR DESCRIPTION
The original implementation was using a V3 token which is set as a query parameter in every request. This will now set the bearer token on every request.